### PR TITLE
Update section titles and clarify Copilot connectors

### DIFF
--- a/docs/data-privacy-security.md
+++ b/docs/data-privacy-security.md
@@ -22,11 +22,11 @@ When you integrate your business workflows as agents for Copilot, your external 
 
 [!INCLUDE [security-note](includes/security-on-das-note.md)]
 
-## Copilot connectors
+## Microsoft 365 Copilot connectors
 
-Microsoft 365 Copilot presents only data that each individual can access using the same underlying controls for data access used in other Microsoft 365 services. Microsoft Graph honors the user identity-based access boundary so that the Copilot grounding process only accesses content that the current user is authorized to access. This is also true of external data within Microsoft Graph ingested from a Copilot connector.
+Microsoft 365 Copilot presents only data that each individual can access using the same underlying controls for data access used in other Microsoft 365 services. Microsoft Graph honors the user identity-based access boundary so that the Microsoft 365 Copilot grounding process only accesses content that the current user is authorized to access. This is also true of external data within Microsoft Graph ingested from a Microsoft 365 Copilot connector.
 
-When you connect your external data to Copilot with a Copilot connector, your data flows into Microsoft Graph. You can manage permissions to view external items by associating an [access control list](/graph/connecting-external-content-manage-items?branch=main#access-control-list) (ACL) with a Microsoft Entra user and group ID or an [external group](/graph/connecting-external-content-external-groups?context=/microsoft-365-copilot/extensibility/context).
+When you connect your external data to Microsoft 365 Copilot with a Microsoft 365 Copilot connector, your data flows into Microsoft Graph. You can manage permissions to view external items by associating an [access control list](/graph/connecting-external-content-manage-items?branch=main#access-control-list) (ACL) with a Microsoft Entra user and group ID or an [external group](/graph/connecting-external-content-external-groups?context=/microsoft-365-copilot/extensibility/context).
 
 Prompts, responses, and data accessed through Microsoft Graph aren't used to train foundation LLMs, including those used by Microsoft 365 Copilot.
 


### PR DESCRIPTION
Talking about Copilot connector in this case can be misleading, because in fact we should talk about "Microsoft 365 Copilot connector. So I have further clarified this concept adding the "Microsoft 365" mention whenever required.