### PR TITLE
Clarify M365 Copilot license requirement for API

### DIFF
--- a/docs/api/ai-services/interaction-export/aiinteractionhistory-getallenterpriseinteractions.md
+++ b/docs/api/ai-services/interaction-export/aiinteractionhistory-getallenterpriseinteractions.md
@@ -1,7 +1,7 @@
 ---
 title: "aiInteractionHistory: getAllEnterpriseInteractions"
 description: Get all Microsoft 365 Copilot interaction data, including user prompts to Copilot and Copilot responses.
-ms.date: 09/26/2025
+ms.date: 11/06/2025
 author: bkeerthivasa
 ms.author: bkeerthivasa
 ms.localizationpriority: high
@@ -24,7 +24,7 @@ Get all Microsoft 365 Copilot interaction data, including user prompts to Copilo
 To learn more about how to use the Microsoft Teams export APIs to export content, see [Export content with the Microsoft Teams export APIs](/microsoftteams/export-teams-content).
 
 > [!NOTE]
-> - A valid M365 Copilot license is required for this API.
+> This API requires a valid Microsoft 365 Copilot license.
 
 ## Permissions
 


### PR DESCRIPTION
Updated note regarding M365 Copilot license requirement for API usage.

PG confirmed in my IcM that previous documentation was wrong.