### PR TITLE
Update instructions for finding Dataverse skill ID

### DIFF
--- a/docs/includes/dataverse-knowledge-skill-location.md
+++ b/docs/includes/dataverse-knowledge-skill-location.md
@@ -7,8 +7,7 @@ ms.localizationpriority: medium
 
 To find the unique `skill` identifier for the Dataverse knowledge sources you want to include:
 
-1. In Copilot Studio, in the left pane, choose **Agents**, and open the **Copilot for Microsoft 365**.
-2. Create a new agent.
+1. In Copilot Studio, in the left pane, choose **Agents** > **Copilot for Microsoft 365**, and select **Add** to create a new agent.
 3. Follow the instructions in [Add a Dataverse knowledge source](https://learn.microsoft.com/microsoft-copilot-studio/knowledge-add-dataverse) to add Dataverse knowledge.
 4. Select **Publish**, and then download the .zip file.
 5. Unzip and open the declarativeAgent.json file.


### PR DESCRIPTION
Updated instructions, as the location for finding this wasn't descriptive enough to find the right area of Copilot Studio to extract the definition. After recently running through the docs, there was a gap here and made it quite hard to work out how to set this up. 

---

This pull request updates the instructions for finding the unique `skill` identifier for Dataverse knowledge sources in the `docs/includes/dataverse-knowledge-skill-location.md` file. The steps now provide more detailed guidance, including agent selection and creation.

Documentation improvements:

* Expanded the step-by-step instructions to include finding the "Copilot for Microsoft 365" agent, creating a new agent, and then proceeding with the process to add and publish a Dataverse knowledge source, making the process clearer for users.