### PR TITLE
Copilot Policy Settings API documentation.

### DIFF
--- a/docs/api/admin-settings/copilotpolicysetting-get.md
+++ b/docs/api/admin-settings/copilotpolicysetting-get.md
@@ -4,7 +4,6 @@ description: "Read the properties and relationships of a copilotPolicySetting ob
 author: "paarava"
 ms.date: 03/19/2026
 ms.localizationpriority: medium
-ms.subservice: "copilot-settings"
 doc_type: apiPageType
 ---
 

--- a/docs/api/admin-settings/copilotpolicysetting-get.md
+++ b/docs/api/admin-settings/copilotpolicysetting-get.md
@@ -1,0 +1,184 @@
+---
+title: "Get copilotPolicySetting"
+description: "Read the properties and relationships of a copilotPolicySetting object."
+author: "paarava"
+ms.date: 03/19/2026
+ms.localizationpriority: medium
+ms.subservice: "copilot-settings"
+doc_type: apiPageType
+---
+
+# Get copilotPolicySetting
+
+Namespace: microsoft.graph
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+Read the properties and relationships of a [copilotPolicySetting](../resources/copilotpolicysetting.md) object.
+
+Retrieve the current value of a Copilot policy setting by its identifier. The API resolves the correct underlying policy service (CPS or Intune) and returns the setting value along with the associated policy ID. When the setting has not been configured or no tenant-level policy exists, the API returns `200 OK` with `value` and/or `policyId` set to `null` — this is not an error condition.
+
+## Permissions
+
+Choose the permission or permissions marked as least privileged for this API. Use a higher privileged permission or permissions [only if your app requires it](/graph/permissions-overview#best-practices-for-using-microsoft-graph-permissions). For details about delegated and application permissions, see [Permission types](/graph/permissions-overview#permission-types). To learn more about these permissions, see the [permissions reference](/graph/permissions-reference).
+
+<!-- {
+  "blockType": "permissions",
+  "name": "copilotpolicysetting-get-permissions"
+}
+-->
+|Permission type|Least privileged permission|Higher privileged permissions|
+|:---|:---|:---|
+|Delegated (work or school account)|Not supported.|Not supported.|
+|Delegated (personal Microsoft account)|Not supported.|Not supported.|
+|Application|Not supported.|Not supported.|
+
+## HTTP request
+
+<!-- {
+  "blockType": "ignored"
+}
+-->
+``` http
+GET /copilot/admin/policySettings/{id}
+```
+
+## Path parameters
+
+|Parameter|Type|Description|
+|:---|:---|:---|
+|id|String|The friendly identifier of the Copilot setting. For example, `microsoft.copilot.pinsetting`. Required.|
+
+## Optional query parameters
+
+This method supports the `$select` OData query parameter to help customize the response. For general information, see [OData query parameters](/graph/query-parameters).
+
+## Request headers
+
+|Name|Description|
+|:---|:---|
+|Authorization|Bearer {token}. Required. Learn more about [authentication and authorization](/graph/auth/auth-concepts).|
+
+## Request body
+
+Don't supply a request body for this method.
+
+## Response
+
+If successful, this method returns a `200 OK` response code and a [copilotPolicySetting](../resources/copilotpolicysetting.md) object in the response body.
+
+## Examples
+
+### Example 1: Get a configured setting
+
+The following example shows how to retrieve a Copilot setting that has been configured with a value in a tenant-level policy.
+
+#### Request
+
+The following example shows a request.
+<!-- {
+  "blockType": "request",
+  "name": "get_copilotpolicysetting_configured"
+}
+-->
+``` http
+GET https://graph.microsoft.com/beta/copilot/admin/policySettings/microsoft.copilot.pinsetting
+```
+
+#### Response
+
+The following example shows the response.
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.copilotPolicySetting"
+}
+-->
+``` http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "@odata.context": "https://graph.microsoft.com/beta/$metadata#copilot/admin/policySettings/$entity",
+  "@odata.type": "#microsoft.graph.copilotPolicySetting",
+  "id": "microsoft.copilot.pinsetting",
+  "value": "1",
+  "policyId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+}
+```
+
+### Example 2: Get an unconfigured setting
+
+The following example shows how to retrieve a setting where a tenant-level policy exists but the setting value has not been configured. The API returns `200 OK` with `value` as `null`.
+
+#### Request
+
+The following example shows a request.
+<!-- {
+  "blockType": "request",
+  "name": "get_copilotpolicysetting_unconfigured"
+}
+-->
+``` http
+GET https://graph.microsoft.com/beta/copilot/admin/policySettings/microsoft.copilot.somesetting
+```
+
+#### Response
+
+The following example shows the response.
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.copilotPolicySetting"
+}
+-->
+``` http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "@odata.context": "https://graph.microsoft.com/beta/$metadata#copilot/admin/policySettings/$entity",
+  "@odata.type": "#microsoft.graph.copilotPolicySetting",
+  "id": "microsoft.copilot.somesetting",
+  "value": null,
+  "policyId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+}
+```
+
+### Example 3: Get a setting when no policy exists
+
+The following example shows how to retrieve a setting where no tenant-level policy has been created yet. The API returns `200 OK` with both `value` and `policyId` as `null`.
+
+#### Request
+
+The following example shows a request.
+<!-- {
+  "blockType": "request",
+  "name": "get_copilotpolicysetting_nopolicy"
+}
+-->
+``` http
+GET https://graph.microsoft.com/beta/copilot/admin/policySettings/microsoft.copilot.anothersetting
+```
+
+#### Response
+
+The following example shows the response.
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.copilotPolicySetting"
+}
+-->
+``` http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "@odata.context": "https://graph.microsoft.com/beta/$metadata#copilot/admin/policySettings/$entity",
+  "@odata.type": "#microsoft.graph.copilotPolicySetting",
+  "id": "microsoft.copilot.anothersetting",
+  "value": null,
+  "policyId": null
+}
+```

--- a/docs/api/admin-settings/copilotpolicysetting-get.md
+++ b/docs/api/admin-settings/copilotpolicysetting-get.md
@@ -28,7 +28,7 @@ Choose the permission or permissions marked as least privileged for this API. Us
 -->
 |Permission type|Least privileged permission|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|Not supported.|Not supported.|
+|Delegated (work or school account)|CopilotPolicySettings.Read|CopilotPolicySettings.ReadWrite|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
 |Application|Not supported.|Not supported.|
 

--- a/docs/api/admin-settings/copilotpolicysetting-get.md
+++ b/docs/api/admin-settings/copilotpolicysetting-get.md
@@ -11,9 +11,9 @@ doc_type: apiPageType
 
 Namespace: microsoft.graph
 
-[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+[!INCLUDE [beta-disclaimer](../includes/beta-disclaimer.md)]
 
-Read the properties and relationships of a [copilotPolicySetting](../resources/copilotpolicysetting.md) object.
+Read the properties and relationships of a [copilotPolicySetting](./resources/copilotpolicysetting.md) object.
 
 Retrieve the current value of a Copilot policy setting by its identifier. The API resolves the correct underlying policy service (CPS or Intune) and returns the setting value along with the associated policy ID. When the setting has not been configured or no tenant-level policy exists, the API returns `200 OK` with `value` and/or `policyId` set to `null` — this is not an error condition.
 
@@ -64,7 +64,7 @@ Don't supply a request body for this method.
 
 ## Response
 
-If successful, this method returns a `200 OK` response code and a [copilotPolicySetting](../resources/copilotpolicysetting.md) object in the response body.
+If successful, this method returns a `200 OK` response code and a [copilotPolicySetting](./resources/copilotpolicysetting.md) object in the response body.
 
 ## Examples
 

--- a/docs/api/admin-settings/copilotpolicysetting-update.md
+++ b/docs/api/admin-settings/copilotpolicysetting-update.md
@@ -4,7 +4,6 @@ description: "Update the properties of a copilotPolicySetting object."
 author: "paarava"
 ms.date: 03/19/2026
 ms.localizationpriority: medium
-ms.subservice: "copilot-settings"
 doc_type: apiPageType
 ---
 

--- a/docs/api/admin-settings/copilotpolicysetting-update.md
+++ b/docs/api/admin-settings/copilotpolicysetting-update.md
@@ -28,7 +28,7 @@ Choose the permission or permissions marked as least privileged for this API. Us
 -->
 |Permission type|Least privileged permission|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|Not supported.|Not supported.|
+|Delegated (work or school account)|CopilotPolicySettings.ReadWrite|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
 |Application|Not supported.|Not supported.|
 

--- a/docs/api/admin-settings/copilotpolicysetting-update.md
+++ b/docs/api/admin-settings/copilotpolicysetting-update.md
@@ -1,0 +1,159 @@
+---
+title: "Update copilotPolicySetting"
+description: "Update the properties of a copilotPolicySetting object."
+author: "paarava"
+ms.date: 03/19/2026
+ms.localizationpriority: medium
+ms.subservice: "copilot-settings"
+doc_type: apiPageType
+---
+
+# Update copilotPolicySetting
+
+Namespace: microsoft.graph
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+Update the properties of a [copilotPolicySetting](../resources/copilotpolicysetting.md) object.
+
+Update the value of a Copilot policy setting. The API resolves the correct underlying policy service and applies the update. If **policyId** is omitted from the request body, the API resolves the first matching tenant-level policy automatically.
+
+## Permissions
+
+Choose the permission or permissions marked as least privileged for this API. Use a higher privileged permission or permissions [only if your app requires it](/graph/permissions-overview#best-practices-for-using-microsoft-graph-permissions). For details about delegated and application permissions, see [Permission types](/graph/permissions-overview#permission-types). To learn more about these permissions, see the [permissions reference](/graph/permissions-reference).
+
+<!-- {
+  "blockType": "permissions",
+  "name": "copilotpolicysetting-update-permissions"
+}
+-->
+|Permission type|Least privileged permission|Higher privileged permissions|
+|:---|:---|:---|
+|Delegated (work or school account)|Not supported.|Not supported.|
+|Delegated (personal Microsoft account)|Not supported.|Not supported.|
+|Application|Not supported.|Not supported.|
+
+## HTTP request
+
+<!-- {
+  "blockType": "ignored"
+}
+-->
+``` http
+PATCH /copilot/admin/policySettings/{id}
+```
+
+## Path parameters
+
+|Parameter|Type|Description|
+|:---|:---|:---|
+|id|String|The friendly identifier of the Copilot setting. For example, `microsoft.copilot.pinsetting`. Required.|
+
+## Request headers
+
+|Name|Description|
+|:---|:---|
+|Authorization|Bearer {token}. Required. Learn more about [authentication and authorization](/graph/auth/auth-concepts).|
+|Content-Type|application/json. Required.|
+
+## Request body
+
+[!INCLUDE [table-intro](../../includes/update-property-table-intro.md)]
+
+|Property|Type|Description|
+|:---|:---|:---|
+|value|String|The new value to set for the setting. The format is setting-specific and may be a digit, URL, XML string, or JSON string. Required.|
+|policyId|String|The ID of the target tenant-level policy. If omitted, the API resolves the first matching tenant-level policy automatically. Optional.|
+
+## Response
+
+If successful, this method returns a `200 OK` response code and an updated [copilotPolicySetting](../resources/copilotpolicysetting.md) object in the response body.
+
+## Examples
+
+### Example 1: Update with policyId specified
+
+The following example shows how to update a Copilot setting value with an explicit policy ID.
+
+#### Request
+
+The following example shows a request.
+<!-- {
+  "blockType": "request",
+  "name": "update_copilotpolicysetting_withpolicyid"
+}
+-->
+``` http
+PATCH https://graph.microsoft.com/beta/copilot/admin/policySettings/microsoft.copilot.pinsetting
+Content-Type: application/json
+
+{
+  "value": "0",
+  "policyId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+}
+```
+
+#### Response
+
+The following example shows the response.
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.copilotPolicySetting"
+}
+-->
+``` http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "@odata.context": "https://graph.microsoft.com/beta/$metadata#copilot/admin/policySettings/$entity",
+  "@odata.type": "#microsoft.graph.copilotPolicySetting",
+  "id": "microsoft.copilot.pinsetting",
+  "value": "0",
+  "policyId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+}
+```
+
+### Example 2: Update without policyId (API resolves automatically)
+
+The following example shows how to update a setting value without specifying a policy ID. The API resolves the first matching tenant-level policy and applies the update.
+
+#### Request
+
+The following example shows a request.
+<!-- {
+  "blockType": "request",
+  "name": "update_copilotpolicysetting_withoutpolicyid"
+}
+-->
+``` http
+PATCH https://graph.microsoft.com/beta/copilot/admin/policySettings/microsoft.copilot.pinsetting
+Content-Type: application/json
+
+{
+  "value": "1"
+}
+```
+
+#### Response
+
+The following example shows the response.
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.copilotPolicySetting"
+}
+-->
+``` http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "@odata.context": "https://graph.microsoft.com/beta/$metadata#copilot/admin/policySettings/$entity",
+  "@odata.type": "#microsoft.graph.copilotPolicySetting",
+  "id": "microsoft.copilot.pinsetting",
+  "value": "1",
+  "policyId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+}
+```

--- a/docs/api/admin-settings/copilotpolicysetting-update.md
+++ b/docs/api/admin-settings/copilotpolicysetting-update.md
@@ -11,9 +11,9 @@ doc_type: apiPageType
 
 Namespace: microsoft.graph
 
-[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+[!INCLUDE [beta-disclaimer](../includes/beta-disclaimer.md)]
 
-Update the properties of a [copilotPolicySetting](../resources/copilotpolicysetting.md) object.
+Update the properties of a [copilotPolicySetting](./resources/copilotpolicysetting.md) object.
 
 Update the value of a Copilot policy setting. The API resolves the correct underlying policy service and applies the update. If **policyId** is omitted from the request body, the API resolves the first matching tenant-level policy automatically.
 
@@ -57,8 +57,6 @@ PATCH /copilot/admin/policySettings/{id}
 
 ## Request body
 
-[!INCLUDE [table-intro](../../includes/update-property-table-intro.md)]
-
 |Property|Type|Description|
 |:---|:---|:---|
 |value|String|The new value to set for the setting. The format is setting-specific and may be a digit, URL, XML string, or JSON string. Required.|
@@ -66,7 +64,7 @@ PATCH /copilot/admin/policySettings/{id}
 
 ## Response
 
-If successful, this method returns a `200 OK` response code and an updated [copilotPolicySetting](../resources/copilotpolicysetting.md) object in the response body.
+If successful, this method returns a `200 OK` response code and an updated [copilotPolicySetting](./resources/copilotpolicysetting.md) object in the response body.
 
 ## Examples
 

--- a/docs/api/admin-settings/resources/copilotadmin.md
+++ b/docs/api/admin-settings/resources/copilotadmin.md
@@ -1,29 +1,30 @@
 ---
-title: "copilotAdmin resource type"
-description: "Represents a container for Copilot admin resources."
-author: "paarava"
-ms.date: 03/19/2026
+title: copilotAdmin resource type
+description: Represents a Microsoft 365 admin who can add or modify Microsoft 365 Copilot settings.
+author: gautamjain14
+ms.author: gajain
 ms.localizationpriority: medium
-ms.subservice: "copilot-settings"
 doc_type: resourcePageType
+ms.topic: reference
+ms.date: 03/19/2026
+zone_pivot_groups: graph-api-versions
 ---
 
 # copilotAdmin resource type
 
-Namespace: microsoft.graph
+<!-- cSpell:ignore gautamjain14 gajain -->
 
+:::zone pivot="graph-v1"
+:::zone-end
+
+:::zone pivot="graph-preview"
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+:::zone-end
 
-Represents a container for Copilot admin resources.
-
-This resource serves as a parent for managing Copilot-related administrative settings and configurations through the `/copilot/admin` endpoint.
-
-Inherits from [entity](../resources/entity.md).
-
-## Methods
-None.
+Represents a container for Microsoft 365 Copilot admin settings.
 
 ## Properties
+
 None.
 
 ## Relationships

--- a/docs/api/admin-settings/resources/copilotadmin.md
+++ b/docs/api/admin-settings/resources/copilotadmin.md
@@ -1,42 +1,46 @@
 ---
-title: copilotAdmin resource type
-description: Represents a Microsoft 365 admin who can add or modify Microsoft 365 Copilot settings.
-author: gautamjain14
-ms.author: gajain
+title: "copilotAdmin resource type"
+description: "Represents a container for Copilot admin resources."
+author: "paarava"
+ms.date: 03/19/2026
 ms.localizationpriority: medium
+ms.subservice: "copilot-settings"
 doc_type: resourcePageType
-ms.topic: reference
-ms.date: 08/08/2025
-zone_pivot_groups: graph-api-versions
 ---
 
 # copilotAdmin resource type
 
-<!-- cSpell:ignore gautamjain14 gajain -->
+Namespace: microsoft.graph
 
-:::zone pivot="graph-v1"
-:::zone-end
-
-:::zone pivot="graph-preview"
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
-:::zone-end
 
-Represents a container for Microsoft 365 Copilot admin settings.
+Represents a container for Copilot admin resources.
+
+This resource serves as a parent for managing Copilot-related administrative settings and configurations through the `/copilot/admin` endpoint.
+
+Inherits from [entity](../resources/entity.md).
+
+## Methods
+None.
 
 ## Properties
-
 None.
 
 ## Relationships
-
-| Relationship | Type                                          | Description                                                                               |
-|:-------------|:----------------------------------------------|:------------------------------------------------------------------------------------------|
-| `settings`   | [copilotAdminSetting](copilotadminsetting.md) | Set of Microsoft 365 Copilot settings that can be added or modified. Read-only. Nullable. |
+|Relationship|Type|Description|
+|:---|:---|:---|
+|policySettings|[copilotPolicySetting](../resources/copilotpolicysetting.md) collection|Collection of Copilot settings managed through policy services. Each setting is addressed individually by its identifier.|
+|settings|[copilotAdminSetting](../resources/copilotadminsetting.md)|Represents the settings for Copilot admin.|
 
 ## JSON representation
-
 The following JSON representation shows the resource type.
-
+<!-- {
+  "blockType": "resource",
+  "keyProperty": "id",
+  "@odata.type": "microsoft.graph.copilotAdmin",
+  "openType": true
+}
+-->
 ``` json
 {
   "@odata.type": "#microsoft.graph.copilotAdmin"

--- a/docs/api/admin-settings/resources/copilotadmin.md
+++ b/docs/api/admin-settings/resources/copilotadmin.md
@@ -30,8 +30,8 @@ None.
 ## Relationships
 |Relationship|Type|Description|
 |:---|:---|:---|
-|policySettings|[copilotPolicySetting](../resources/copilotpolicysetting.md) collection|Collection of Copilot settings managed through policy services. Each setting is addressed individually by its identifier.|
-|settings|[copilotAdminSetting](../resources/copilotadminsetting.md)|Represents the settings for Copilot admin.|
+|policySettings|[copilotPolicySetting](copilotpolicysetting.md) collection|Collection of Copilot settings managed through policy services. Each setting is addressed individually by its identifier.|
+|settings|[copilotAdminSetting](copilotadminsetting.md)|Represents the settings for Copilot admin.|
 
 ## JSON representation
 The following JSON representation shows the resource type.

--- a/docs/api/admin-settings/resources/copilotpolicysetting.md
+++ b/docs/api/admin-settings/resources/copilotpolicysetting.md
@@ -19,18 +19,18 @@ This resource is accessed through the `/copilot/admin/policySettings/{id}` endpo
 
 This resource is a contained entity within the [copilotAdmin](copilotadmin.md) resource.
 
-Inherits from [entity](../resources/entity.md).
+Inherits from [entity](/graph/api/resources/entity).
 
 ## Methods
 |Method|Return type|Description|
 |:---|:---|:---|
-|[Get](../api/copilotpolicysetting-get.md)|[copilotPolicySetting](../resources/copilotpolicysetting.md)|Read the properties and relationships of a [copilotPolicySetting](../resources/copilotpolicysetting.md) object.|
-|[Update](../api/copilotpolicysetting-update.md)|[copilotPolicySetting](../resources/copilotpolicysetting.md)|Update the properties of a [copilotPolicySetting](../resources/copilotpolicysetting.md) object.|
+|[Get](../copilotpolicysetting-get.md)|[copilotPolicySetting](copilotpolicysetting.md)|Read the properties and relationships of a [copilotPolicySetting](copilotpolicysetting.md) object.|
+|[Update](../copilotpolicysetting-update.md)|[copilotPolicySetting](copilotpolicysetting.md)|Update the properties of a [copilotPolicySetting](copilotpolicysetting.md) object.|
 
 ## Properties
 |Property|Type|Description|
 |:---|:---|:---|
-|id|String|The friendly identifier of the Copilot setting (for example, `microsoft.copilot.pinsetting`). Used as the resource key in the URL path. Read-only. Inherited from [entity](../resources/entity.md).|
+|id|String|The friendly identifier of the Copilot setting (for example, `microsoft.copilot.pinsetting`). Used as the resource key in the URL path. Read-only. Inherited from [entity](/graph/api/resources/entity).|
 |policyId|String|The ID of the tenant-level policy containing this setting in the underlying policy service. Nullable. Returns `null` when no tenant-level policy exists for this setting. If omitted on update, the API resolves the first matching tenant-level policy.|
 |value|String|The current value of the setting as a string. The format is setting-specific and may be a digit representing a state (for example, `0`, `1`), a URL, an XML string, or a JSON string. Nullable. Returns `null` when the setting has not been configured in the resolved tenant-level policy.|
 

--- a/docs/api/admin-settings/resources/copilotpolicysetting.md
+++ b/docs/api/admin-settings/resources/copilotpolicysetting.md
@@ -1,0 +1,56 @@
+---
+title: "copilotPolicySetting resource type"
+description: "Represents a Copilot setting managed through a policy service (CPS or Intune), accessed via the /copilot/admin/policySettings endpoint."
+author: "paarava"
+ms.date: 03/19/2026
+ms.localizationpriority: medium
+ms.subservice: "copilot-settings"
+doc_type: resourcePageType
+---
+
+# copilotPolicySetting resource type
+
+Namespace: microsoft.graph
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+Represents a Copilot setting that is managed through a policy service (CPS or Intune). 
+
+This resource is accessed through the `/copilot/admin/policySettings/{id}` endpoint, where the API resolves the correct underlying policy service automatically. Settings are addressed individually by their identifier, and only tenant-level policies are supported. User-level and group-level policies are not supported.
+
+This resource is a contained entity within the [copilotAdmin](copilotadmin.md) resource.
+
+Inherits from [entity](../resources/entity.md).
+
+## Methods
+|Method|Return type|Description|
+|:---|:---|:---|
+|[Get](../api/copilotpolicysetting-get.md)|[copilotPolicySetting](../resources/copilotpolicysetting.md)|Read the properties and relationships of a [copilotPolicySetting](../resources/copilotpolicysetting.md) object.|
+|[Update](../api/copilotpolicysetting-update.md)|[copilotPolicySetting](../resources/copilotpolicysetting.md)|Update the properties of a [copilotPolicySetting](../resources/copilotpolicysetting.md) object.|
+
+## Properties
+|Property|Type|Description|
+|:---|:---|:---|
+|id|String|The friendly identifier of the Copilot setting (for example, `microsoft.copilot.pinsetting`). Used as the resource key in the URL path. Read-only. Inherited from [entity](../resources/entity.md).|
+|policyId|String|The ID of the tenant-level policy containing this setting in the underlying policy service. Nullable. Returns `null` when no tenant-level policy exists for this setting. If omitted on update, the API resolves the first matching tenant-level policy.|
+|value|String|The current value of the setting as a string. The format is setting-specific and may be a digit representing a state (for example, `0`, `1`), a URL, an XML string, or a JSON string. Nullable. Returns `null` when the setting has not been configured in the resolved tenant-level policy.|
+
+## Relationships
+None.
+
+## JSON representation
+The following JSON representation shows the resource type.
+<!-- {
+  "blockType": "resource",
+  "keyProperty": "id",
+  "@odata.type": "microsoft.graph.copilotPolicySetting"
+}
+-->
+``` json
+{
+  "@odata.type": "#microsoft.graph.copilotPolicySetting",
+  "id": "String (identifier)",
+  "value": "String",
+  "policyId": "String"
+}
+```

--- a/docs/api/admin-settings/resources/copilotpolicysetting.md
+++ b/docs/api/admin-settings/resources/copilotpolicysetting.md
@@ -4,7 +4,6 @@ description: "Represents a Copilot setting managed through a policy service (CPS
 author: "paarava"
 ms.date: 03/19/2026
 ms.localizationpriority: medium
-ms.subservice: "copilot-settings"
 doc_type: resourcePageType
 ---
 

--- a/docs/api/admin-settings/toc.yml
+++ b/docs/api/admin-settings/toc.yml
@@ -7,6 +7,14 @@ items:
     href: copilotadminlimitedmode-get.md
   - name: Update
     href: copilotadminlimitedmode-update.md
+- name: Copilot policy setting
+  items:
+  - name: Copilot policy setting
+    href: resources/copilotpolicysetting.md
+  - name: Get
+    href: copilotpolicysetting-get.md
+  - name: Update
+    href: copilotpolicysetting-update.md
 - name: Copilot usage reports API
   href: reports/toc.yml
 - name: Package management API (preview)
@@ -17,3 +25,5 @@ items:
     href: resources/copilotadmin.md
   - name: Copilot admin setting
     href: resources/copilotadminsetting.md
+  - name: Copilot policy setting
+    href: resources/copilotpolicysetting.md


### PR DESCRIPTION
This documentation is for the new Copilot policy settings API, a unified Graph API that enables tenant administrators and partner services to read and update Copilot policy settings.

Review PR: [44260-MS-Graph-API-for-Copilot-Settings-Across-Multiple-Policy-Stores](https://msazure.visualstudio.com/One/_git/AD-AggregatorService-Workloads/pullrequest/14940360)
Link to PR for public-facing schema changes (schema-Prod-beta/v1.0.csdl): [15076157](https://dev.azure.com/msazure/One/_git/AD-AggregatorService-Workloads/pullrequest/15076157)