### PR TITLE
Update Microsoft 365 Agents Toolkit version requirement

### DIFF
--- a/docs/declarative-agent-ui-widgets.md
+++ b/docs/declarative-agent-ui-widgets.md
@@ -31,7 +31,7 @@ For details on which OpenAI Apps SDK capabilities are supported, see [Supported 
 - A remote MCP server that provides UI widgets or that you can modify to implement UI widgets
 - A tool to view MCP server responses, such as [MCP Inspector](https://www.npmjs.com/package/@modelcontextprotocol/inspector)
 - [Visual Studio Code](https://code.visualstudio.com/)
-- The latest version of the [Microsoft 365 Agents Toolkit](https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension) (version 6.6.1 or later)
+- [Microsoft 365 Agents Toolkit](https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension) (version 6.6.1 or later)
 
 ## MCP server requirements
 


### PR DESCRIPTION
v6.6.1 is out and now supports automatically fetching full mcp tool definition. No need to manually add it in mcp-tools.json