### PR TITLE
Update work-iq-cli.md and fix the "install ins VS Code/Insiders" links

### DIFF
--- a/docs/work-iq-cli.md
+++ b/docs/work-iq-cli.md
@@ -5,7 +5,7 @@ author: slevert
 ms.author: slevert
 ms.topic: overview
 ms.localizationpriority: medium
-ms.date: 01/23/2026
+ms.date: 05/12/2026
 ---
 
 <!-- markdownlint-disable MD024 -->
@@ -117,8 +117,8 @@ npx -y @microsoft/workiq mcp
 
 Use the following links to add Work IQ as an MCP server in VS Code:
 
-- [Install in VS Code](<https://vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40microsoft%2Fworkiq%22%2C%22mcp%22%5D%2C%22name%22%3A%22workiq%22%7D>)
-- [Install in VS Code Insiders](<https://insiders.vscode.dev/redirect?url=vscode-insiders%3Amcp%2Finstall%3F%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40microsoft%2Fworkiq%22%2C%22mcp%22%5D%2C%22name%22%3A%22workiq%22%7D>)
+- [Install in VS Code](https://vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40microsoft%2Fworkiq%22%2C%22mcp%22%5D%2C%22name%22%3A%22workiq%22%7D)
+- [Install in VS Code Insiders](https://insiders.vscode.dev/redirect?url=vscode-insiders%3Amcp%2Finstall%3F%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40microsoft%2Fworkiq%22%2C%22mcp%22%5D%2C%22name%22%3A%22workiq%22%7D)
 
 ### Manual MCP configuration
 

--- a/docs/work-iq-cli.md
+++ b/docs/work-iq-cli.md
@@ -117,8 +117,8 @@ npx -y @microsoft/workiq mcp
 
 Use the following links to add Work IQ as an MCP server in VS Code:
 
-- [Install in VS Code](https://vscode.dev/redirect/mcp/install?name=workiq&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40microsoft%2Fworkiq%22%2C%22mcp%22%5D%7D)
-- [Install in VS Code Insiders](https://insiders.vscode.dev/redirect/mcp/install?name=workiq&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40microsoft%2Fworkiq%22%2C%22mcp%22%5D%7D&quality=insiders)
+- [Install in VS Code](<https://vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40microsoft%2Fworkiq%22%2C%22mcp%22%5D%2C%22name%22%3A%22workiq%22%7D>)
+- [Install in VS Code Insiders](<https://insiders.vscode.dev/redirect?url=vscode-insiders%3Amcp%2Finstall%3F%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40microsoft%2Fworkiq%22%2C%22mcp%22%5D%2C%22name%22%3A%22workiq%22%7D>)
 
 ### Manual MCP configuration
 


### PR DESCRIPTION
The install in VS Code and Insiders links for workiq MCP server where broken.

Fixed the links, well, Copilot did, but I will take credit. Tried in Edge with both current version of VS Code and VS Code Insiders.