### PR TITLE
remove misleading reference to SPFx

### DIFF
--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -5,7 +5,7 @@ author: erikadoyle
 ms.author: edoyle
 ms.topic: overview
 ms.localizationpriority: medium
-ms.date: 09/12/2025
+ms.date: 05/11/2026
 ---
 
 # Copilot extensibility in the Microsoft 365 ecosystem
@@ -64,7 +64,7 @@ Microsoft is simplifying the way Microsoft 365 Copilot extensibility and other M
 
 ## Unified app model
 
-The Microsoft 365 ecosystem provides a unified app model for distributing and managing agents, Teams apps, Outlook Add-ins, SharePoint Framework solutions, and more. The app package for Microsoft 365 is a zip file that contains one or more configuration (manifest) files and your app icons.
+The Microsoft 365 ecosystem provides a unified app model for distributing and managing agents, Teams apps, Office Add-ins, and more. The app package for Microsoft 365 is a zip file that contains one or more configuration (manifest) files and your app icons.
 
 To learn more, see [Agents are apps for Microsoft 365](agents-are-apps.md).
 


### PR DESCRIPTION
The reference to SharePoint Framework here is not really correct. An SPFx project CANNOT be included in an M365 unified manifest or M365 app package. Although some Teams apps can be implemented as SPFx pages, those pages have to be separately installed on SharePoint with the SharePoint manifest, which is NOT the unified manifest for M365. 

Also, the unified manifest now supports Excel, PowerPoint, and Word, as well as Outlook.