### PR TITLE
Update Work IQ Rest API endpoints in docs

### DIFF
--- a/docs/work-iq/rest/copilotconversation-chat.md
+++ b/docs/work-iq/rest/copilotconversation-chat.md
@@ -4,7 +4,7 @@ description: Continue synchronous conversations with the Work IQ Chat API.
 author: marina-hayrapetyan
 ms.author: mhayrapetyan
 ms.topic: reference
-ms.date: 05/15/2026
+ms.date: 06/10/2026
 ms.localizationpriority: medium
 doc_type: apiPageType
 ---
@@ -33,7 +33,7 @@ This documentation covers continuing synchronous Copilot conversations using the
 ## HTTP request
 
 ```http
-POST https://workiq.svc.cloud.microsoft/rest/beta/copilot/conversations/{conversationId}/chat
+POST https://workiq.svc.cloud.microsoft/rest/beta/conversations/{conversationId}/chat
 ```
 
 ## Request headers
@@ -71,7 +71,7 @@ The following example shows how to send a prompt to the Chat API using the synch
 The following example shows the request.
 
 ```http
-POST https://workiq.svc.cloud.microsoft/rest/beta/copilot/conversations/0d110e7e-2b7e-4270-a899-fd2af6fde333/chat
+POST https://workiq.svc.cloud.microsoft/rest/beta/conversations/0d110e7e-2b7e-4270-a899-fd2af6fde333/chat
 Content-Type: application/json
 
 {
@@ -177,7 +177,7 @@ The following example shows how to use a OneDrive or SharePoint file as context 
 The following example shows the request.
 
 ```http
-POST https://workiq.svc.cloud.microsoft/rest/beta/copilot/conversations/0d110e7e-2b7e-4270-a899-fd2af6fde333/chat
+POST https://workiq.svc.cloud.microsoft/rest/beta/conversations/0d110e7e-2b7e-4270-a899-fd2af6fde333/chat
 Content-Type: application/json
 
 {
@@ -280,7 +280,7 @@ The following example shows how to toggle off web search grounding when sending 
 The following example shows the request.
 
 ```http
-POST https://workiq.svc.cloud.microsoft/rest/beta/copilot/conversations/0d110e7e-2b7e-4270-a899-fd2af6fde333/chat
+POST https://workiq.svc.cloud.microsoft/rest/beta/conversations/0d110e7e-2b7e-4270-a899-fd2af6fde333/chat
 Content-Type: application/json
 
 {
@@ -360,7 +360,7 @@ The following example shows how to send more context with a chat message to the 
 The following example shows the request.
 
 ```http
-POST https://workiq.svc.cloud.microsoft/rest/beta/copilot/conversations/0d110e7e-2b7e-4270-a899-fd2af6fde333/chat
+POST https://workiq.svc.cloud.microsoft/rest/beta/conversations/0d110e7e-2b7e-4270-a899-fd2af6fde333/chat
 Content-Type: application/json
 
 {

--- a/docs/work-iq/rest/copilotconversation-chatoverstream.md
+++ b/docs/work-iq/rest/copilotconversation-chatoverstream.md
@@ -4,7 +4,7 @@ description: Continue streamed conversations with the Work IQ Chat API.
 author: marina-hayrapetyan
 ms.author: mhayrapetyan
 ms.topic: reference
-ms.date: 05/15/2026
+ms.date: 06/10/2026
 ms.localizationpriority: medium
 doc_type: apiPageType
 ---
@@ -33,7 +33,7 @@ This documentation covers continuing streamed Copilot conversations using the Ch
 ## HTTP request
 
 ```http
-POST https://workiq.svc.cloud.microsoft/rest/beta/copilot/conversations/{conversationId}/chatOverStream
+POST https://workiq.svc.cloud.microsoft/rest/beta/conversations/{conversationId}/chatOverStream
 ```
 
 ## Request headers
@@ -71,7 +71,7 @@ The following example shows how to send a prompt to the Chat API using the strea
 The following example shows the request.
 
 ```http
-POST https://workiq.svc.cloud.microsoft/rest/beta/copilot/conversations/d0f6bffa-49d4-43c6-b93b-e7183f92b765/chatOverStream
+POST https://workiq.svc.cloud.microsoft/rest/beta/conversations/d0f6bffa-49d4-43c6-b93b-e7183f92b765/chatOverStream
 Content-Type: application/json
 
 {
@@ -271,7 +271,7 @@ The following example shows how to use a OneDrive or SharePoint file as context 
 The following example shows the request.
 
 ```http
-POST https://workiq.svc.cloud.microsoft/rest/beta/copilot/conversations/d0f6bffa-49d4-43c6-b93b-e7183f92b765/chatOverStream
+POST https://workiq.svc.cloud.microsoft/rest/beta/conversations/d0f6bffa-49d4-43c6-b93b-e7183f92b765/chatOverStream
 Content-Type: application/json
 
 {
@@ -458,7 +458,7 @@ The following example shows how to toggle off web search grounding when sending 
 The following example shows the request.
 
 ```http
-POST https://workiq.svc.cloud.microsoft/rest/beta/copilot/conversations/d0f6bffa-49d4-43c6-b93b-e7183f92b765/chatOverStream
+POST https://workiq.svc.cloud.microsoft/rest/beta/conversations/d0f6bffa-49d4-43c6-b93b-e7183f92b765/chatOverStream
 Content-Type: application/json
 
 {
@@ -623,7 +623,7 @@ The following example shows how to send more context with a chat message to the 
 The following example shows the request.
 
 ```http
-POST https://workiq.svc.cloud.microsoft/rest/beta/copilot/conversations/d0f6bffa-49d4-43c6-b93b-e7183f92b765/chatOverStream
+POST https://workiq.svc.cloud.microsoft/rest/beta/conversations/d0f6bffa-49d4-43c6-b93b-e7183f92b765/chatOverStream
 Content-Type: application/json
 
 {

--- a/docs/work-iq/rest/copilotroot-post-conversations.md
+++ b/docs/work-iq/rest/copilotroot-post-conversations.md
@@ -4,7 +4,7 @@ description: Use the Work IQ Chat API to integrate Microsoft 365 Copilot into yo
 author: marina-hayrapetyan
 ms.author: mhayrapetyan
 ms.topic: reference
-ms.date: 05/15/2026
+ms.date: 06/10/2026
 ms.localizationpriority: medium
 doc_type: apiPageType
 ---
@@ -33,7 +33,7 @@ This documentation covers creating Copilot conversations using the Chat API. Lea
 ## HTTP request
 
 ```http
-POST https://workiq.svc.cloud.microsoft/rest/beta/copilot/conversations
+POST https://workiq.svc.cloud.microsoft/rest/beta/conversations
 ```
 
 ## Request headers
@@ -60,7 +60,7 @@ The following example shows how to create a Copilot conversation through the Wor
 The following example shows the request.
 
 ```http
-POST https://workiq.svc.cloud.microsoft/rest/beta/copilot/conversations
+POST https://workiq.svc.cloud.microsoft/rest/beta/conversations
 Content-Type: application/json
 
 {}


### PR DESCRIPTION
The /chat and /chatOverStream Work IQ API endpoints return a 404 not found. Removing /copilot/ from the paths results in a successful response. 

The sample code does not include /copilot in the path for all three endpoints: https://github.com/microsoft/work-iq-samples/blob/779eb356c96fa39080e046fd0567c8445937c8aa/dotnet/rest/Program.cs#L18

Changes:
- Updated all three endpoint docs (/conversations, /chat, /chatOverStream) to reference the correct path

### Currently Failing
<img width="2100" height="930" alt="image" src="https://github.com/user-attachments/assets/a32be012-0b65-46e8-a01b-ef3b54c055da" />

<img width="2111" height="962" alt="image" src="https://github.com/user-attachments/assets/f71dae78-64f8-4226-80b6-cd5a47ee0cda" />

### Updated Endpoints
<img width="2124" height="912" alt="image" src="https://github.com/user-attachments/assets/b8d6de85-8cc6-44f4-a4b0-6926544626d3" />

