### PR TITLE
docs: add Email and Meeting actions to Agent Builder capabilities

### DIFF
--- a/docs/agent-builder-build-agents.md
+++ b/docs/agent-builder-build-agents.md
@@ -4,7 +4,7 @@ description: Learn how to build agents by using the Agent Builder feature in Mic
 author: jasonxian-msft
 ms.author: jasonxian
 ms.localizationpriority: medium
-ms.date: 05/26/2026
+ms.date: 06/15/2026
 ms.topic: article
 ms.service: copilot-studio
 ms.subservice: agent-builder
@@ -119,6 +119,18 @@ Use natural language to add capabilities on the **Describe** tab, or configure t
 
 - [Code interpreter](code-interpreter.md) - Solves complex math problems, analyzes data, and generates visualizations. To add this capability, select the toggle next to **Create documents, charts, and code**.
 - [Image generator](image-generator.md) - Generates images based on user prompts. To add this capability, select the toggle next to **Create images**.
+
+### Built-in actions
+
+Every agent you build in Agent Builder can also take action on the user's behalf across their Outlook emails and meetings, just like in Microsoft 365 Copilot Chat. These capabilities are always available and use the user's existing permissions.
+
+| Capability | What the agent can do |
+| ---------- | --------------------- |
+| **Email actions** | Manage and send mail in Outlook on the user's behalf: triage messages (archive, flag, pin, move, copy, mark as read, report junk), send mail with the user's confirmation, delete messages, manage inbox rules and automatic replies, and organize folders. |
+| **Meeting actions** | Manage the user's calendar: schedule meetings, create time-finding polls, reclaim meeting time, and surface Viva Insights time analytics. |
+
+> [!NOTE]
+> Email and meeting actions are always on.
 
 ## Set the default response mode
 

--- a/docs/agent-builder-build-agents.md
+++ b/docs/agent-builder-build-agents.md
@@ -120,7 +120,7 @@ Use natural language to add capabilities on the **Describe** tab, or configure t
 - [Code interpreter](code-interpreter.md) - Solves complex math problems, analyzes data, and generates visualizations. To add this capability, select the toggle next to **Create documents, charts, and code**.
 - [Image generator](image-generator.md) - Generates images based on user prompts. To add this capability, select the toggle next to **Create images**.
 
-### Built-in actions
+## Built-in actions
 
 Every agent you build in Agent Builder can also take action on the user's behalf across their Outlook emails and meetings, just like in Microsoft 365 Copilot Chat. These capabilities are always available and use the user's existing permissions.
 


### PR DESCRIPTION
## Summary

Adds **Email actions** and **Meeting actions** as built-in, always-on capabilities under the **Add capabilities** section of the Agent Builder docs. Unlike Code interpreter and Image generator (opt-in toggles), these act on the user's behalf in Outlook and across their calendar, just like in Microsoft 365 Copilot Chat.

## Context

These capabilities are being added to **Declarative agent schema 1.8** for Microsoft 365 Copilot. Agent Builder is currently on [schema 1.7](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/declarative-agent-manifest-1.7?tabs=json); the new `EmailActions` and `MeetingActions` capability types arrive in 1.8 and are always on for agents built in Agent Builder.

## Changes

- `docs/agent-builder-build-agents.md` — new **Built-in actions** subsection (Email actions, Meeting actions) within **Add capabilities**.

## Related work items

- Agent Builder epic: [AB#37705980 — EmailActions and MeetingActions always on](https://msazure.visualstudio.com/CCI/_workitems/edit/37705980)
- Content request: [bacx/content #47153](https://dev.azure.com/bacx/content/_workitems/edit/47153)

## Reviewer notes

- The action lists follow the docs request summary. Please confirm the exact set shipping in schema 1.8 / GA before publishing (the underlying work item tracks a narrower validated subset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
