### PR TITLE
Updating availability of permission types in Copilot package documentation

### DIFF
--- a/docs/api/admin-settings/package/copilotpackage-reassign.md
+++ b/docs/api/admin-settings/package/copilotpackage-reassign.md
@@ -30,7 +30,7 @@ Choose the permission or permissions marked as least privileged for this API. Us
 |:---------------------------------------|:------------------------------|:------------------------------|
 | Delegated (work or school account)     | CopilotPackages.ReadWrite.All | Not available.                |
 | Delegated (personal Microsoft account) | Not supported.                | Not supported.                |
-| Application                            | CopilotPackages.ReadWrite.All | Not available.                |
+| Application                            | Not available.                | Not available.                |
 
 ## HTTP request
 


### PR DESCRIPTION
Updating availability of permission types in Copilot package documentation.

Discussed with PG in **51000001048051**.
_Application (app-only) access token permissions are currently not supported for the POST /packages('{key}')/microsoft.graph.block endpoint._