### PR TITLE
docs: clarify multi-tenant issuer requirement for Work IQ auth

### DIFF
--- a/docs/work-iq/api-overview.md
+++ b/docs/work-iq/api-overview.md
@@ -5,7 +5,7 @@ author: jasonjoh
 ms.author: jasonjoh
 ms.topic: overview
 ms.localizationpriority: medium
-ms.date: 06/02/2026
+ms.date: 06/29/2026
 ---
 
 <!-- markdownlint-disable MD024 -->
@@ -237,7 +237,7 @@ Work IQ uses Microsoft Entra ID delegated authentication.
 - Application-only authentication isn't supported.
 - Microsoft 365 permissions, sensitivity labels, and compliance policies are enforced automatically.
 > [!IMPORTANT]
-> In multi-tenant (parent/child) organizations, the access token's issuer (`iss`) must match the tenant the signed-in user belongs to, not the tenant where the app is registered. Work IQ being enabled in both tenants isn't enough. Register the app as multi-tenant (`AzureADMultipleOrgs`) and have users sign in through their home tenant's authority. Otherwise the request fails with `400 AuthenticationError: "Error authenticating with resource"`.
+> In multi-tenant (parent/child) organizations, the access token's issuer (`iss`) must match the tenant the signed-in user belongs to, not the tenant where the app is registered. Work IQ enabled in both tenants isn't enough. Register the app as multi-tenant (`AzureADMultipleOrgs`) and have users sign in through their home tenant's authority. Otherwise, the request fails with `400 AuthenticationError: "Error authenticating with resource"`.
 ## Path forward for new development
 
 Work IQ is the recommended foundation for new agentic and AI-powered applications on Microsoft 365 data. Build new development on Work IQ APIs to take advantage of unified protocols, integrated governance, and continued investment.

--- a/docs/work-iq/api-overview.md
+++ b/docs/work-iq/api-overview.md
@@ -236,7 +236,8 @@ Work IQ uses Microsoft Entra ID delegated authentication.
 - On-behalf-of (OBO) flows are supported.
 - Application-only authentication isn't supported.
 - Microsoft 365 permissions, sensitivity labels, and compliance policies are enforced automatically.
-
+> [!IMPORTANT]
+> In multi-tenant (parent/child) organizations, the access token's issuer (`iss`) must match the tenant the signed-in user belongs to, not the tenant where the app is registered. Work IQ being enabled in both tenants isn't enough. Register the app as multi-tenant (`AzureADMultipleOrgs`) and have users sign in through their home tenant's authority. Otherwise the request fails with `400 AuthenticationError: "Error authenticating with resource"`.
 ## Path forward for new development
 
 Work IQ is the recommended foundation for new agentic and AI-powered applications on Microsoft 365 data. Build new development on Work IQ APIs to take advantage of unified protocols, integrated governance, and continued investment.


### PR DESCRIPTION
﻿The Authentication and security section doesn't cover multi-tenant (parent/child) orgs. When the app is registered in one tenant but users sign in from another, calls fail with 400 AuthenticationError: "Error authenticating with resource" — even when Work IQ is enabled in both tenants. The token issuer (iss) must match the user's home tenant, and the app must be registered multi-tenant (AzureADMultipleOrgs). This adds a short note. Surfaced from a real customer (parent/child) case. Related sample: microsoft/work-iq-samples PR #22.
